### PR TITLE
Removing s.date

### DIFF
--- a/longshoreman.gemspec
+++ b/longshoreman.gemspec
@@ -1,7 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'longshoreman'
-  s.version       = '0.0.4'
-  s.date          = '2015-06-08'
+  s.version       = '0.0.5'
   s.summary       = 'A helper Gem for using the Docker API'
   s.description   = 'This gem is intended to aid in using Docker images and containers, specifically with regards to integration testing in RSpec.'
   s.authors       = ['Aaron Mildenstein']


### PR DESCRIPTION
This should let the date be automatic for gem versioning
