### PR TITLE
update CapAdd param to be an array

### DIFF
--- a/lib/longshoreman/container.rb
+++ b/lib/longshoreman/container.rb
@@ -48,7 +48,7 @@ class Longshoreman::Container
       'Hostname' => name,
       'Image' => i,
       'PublishAllPorts' => true,
-      'CapAdd' => 'NET_ADMIN',
+      'CapAdd' => ['NET_ADMIN'],
     }
     @raw = Docker::Container.create(main_args.merge(extra_args))
   end

--- a/longshoreman.gemspec
+++ b/longshoreman.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'longshoreman'
-  s.version       = '0.0.5'
+  s.version       = '0.0.6'
   s.summary       = 'A helper Gem for using the Docker API'
   s.description   = 'This gem is intended to aid in using Docker images and containers, specifically with regards to integration testing in RSpec.'
   s.authors       = ['Aaron Mildenstein']


### PR DESCRIPTION
This is the proper API spec, not sure why previous versions of docker did not complain. Docker 1.7 started rejecting this configuration as a simple string.
