### PR TITLE
add ability to pull in image from docker registry

### DIFF
--- a/lib/longshoreman.rb
+++ b/lib/longshoreman.rb
@@ -34,6 +34,10 @@ class Longshoreman
     @image.cleanup
   end
 
+  def self.pull_image(image, tag)
+    `docker pull #{image}:#{tag}`
+  end
+
   attr_reader :ip
   attr_accessor :container
   attr_accessor :image


### PR DESCRIPTION
I do not think this is ideal, but Docker does not really provide another way to pull new images.

here is a discussion surrounding more features around image pulls: https://github.com/docker/docker/issues/6928
